### PR TITLE
Updated Striker to work with Cobalt Strike 4.6+ 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="payload_automation",
-    version="1.0.5",
+    version="1.0.6",
     author="Faultline",
     author_email="jahawkins623@gmail.com",
-    description="A set of libraries to help be a bridge between Sleep and Python, helping to automate payload development, testing, opsec checking, and deployment for Cobalt Strike",
+    description="A set of libraries to help be a bridge between Sleep and Python, helping to automate payload development, testing, opsec checking, beacon tasking, and deployment for Cobalt Strike",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/emcghee/PayloadAutomation",
@@ -25,7 +25,7 @@ setuptools.setup(
         'ptyprocess>=0.5',
         'pexpect',
         'magicfile',
-	'PyYAML==5.4.1'
+	    'PyYAML==5.4.1'
     ],
     download_url = 'https://github.com/emcghee/PayloadAutomation/archive/refs/tags/1.0.1.tar.gz',
 )


### PR DESCRIPTION
Also added logic to allow users to pass a cobalt strike directory ending in a / or just the full path to the jar